### PR TITLE
Add the option to have the vertical nav bar expanded, showing the …

### DIFF
--- a/demo/px-app-nav-demo.html
+++ b/demo/px-app-nav-demo.html
@@ -266,11 +266,7 @@ limitations under the License.
       var div = this.$$('#wrapper');
       if(vertical) {
         div.style.top = '10px';
-        if(verticalExpanded) {
-          div.style.left = '350px';
-        } else {
-          div.style.left = '90px';
-        }
+        div.style.left = verticalExpanded ? '350px' : '90px';
       } else {
         div.style.top = '20px';
         div.style.left = '10px';

--- a/demo/px-app-nav-demo.html
+++ b/demo/px-app-nav-demo.html
@@ -73,6 +73,7 @@ limitations under the License.
         id="appNav"
         items="[[props.items.value]]"
         vertical="[[props.vertical.value]]"
+        vertical-expanded="[[props.verticalExpanded.value]]"
         collapse-with-icon="[[props.collapseWithIcon.value]]"
         collapse-all="[[props.collapseAll.value]]"
         collapse-at="[[props.collapseAt.value]]"
@@ -149,6 +150,11 @@ limitations under the License.
               vertical: true,
               configReset: true
             }, {
+              configName: "Vertical Expanded",
+              vertical: true,
+              verticalExpanded: true,
+              configReset: true
+            }, {
               configName: "Collapsed All",
               collapseAll: true,
               configReset: true
@@ -191,6 +197,11 @@ limitations under the License.
         defaultValue: false,
         inputType: 'toggle',
       },
+      verticalExpanded: {
+        type: Boolean,
+        defaultValue: false,
+        inputType: 'toggle',
+      },
       collapseWithIcon: {
         type: Boolean,
         defaultValue: false,
@@ -221,7 +232,7 @@ limitations under the License.
 
     },
 
-    observers: [ '_returnPos(props.vertical.value)' ],
+    observers: [ '_returnPos(props.vertical.value, props.verticalExpanded.value)' ],
 
 
     listeners: {
@@ -251,11 +262,15 @@ limitations under the License.
       return JSON.stringify(json);
     },
 
-    _returnPos: function(vertical) {
+    _returnPos: function(vertical, verticalExpanded) {
       var div = this.$$('#wrapper');
       if(vertical) {
         div.style.top = '10px';
-        div.style.left = '90px';
+        if(verticalExpanded) {
+          div.style.left = '350px';
+        } else {
+          div.style.left = '90px';
+        }
       } else {
         div.style.top = '20px';
         div.style.left = '10px';

--- a/examples/vertical-expanded.html
+++ b/examples/vertical-expanded.html
@@ -1,0 +1,121 @@
+<!--
+Copyright (c) 2018, General Electric
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>App Nav Demo -- Vertical</title>
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <link rel="import" href="../../polymer/polymer.html"/>
+  <link rel="import" href="../../polymer/lib/elements/dom-bind.html">
+  <link rel="import" href="../../px-theme/px-theme-styles.html"/>
+  <link rel="import" href="../px-app-nav.html"/>
+
+  <style>
+    html, body {
+      margin: 0;
+      font-size: 15px;
+      font-family: 'GE Inspira Sans';
+    }
+    #app {
+      display: block;
+      margin-left: 325px;
+    }
+    px-app-nav {
+      position: fixed;
+      right: 0;
+      top: 0;
+    }
+
+    /*
+     * Tip: It helps to pick a static height for your actions container.
+     * Then you can size/position your actions within this container.
+     *
+     * If you want the height to be dynamically calculated (e.g. you don't
+     * know how many actions you will have), don't set a static height and
+     * ensure the actions container is display: block or display: flex, and
+     * the container will automatically grow to fill the space it needs.
+     */
+    .actions {
+      height: 60px;
+      padding: 0 1rem;
+      display: flex;
+      background-color: cornflowerblue;
+      cursor: pointer;
+    }
+    .actions-collapsed {
+      display: flex;
+      flex: 1 1 auto;
+      align-items: center;
+      justify-content: center;
+    }
+    .actions-expanded {
+      display: flex;
+      flex: 1 1 auto;
+      align-items: center;
+    }
+    .email-address {
+      margin-right: 1rem;
+    }
+  </style>
+</head>
+<body>
+  <custom-style>
+    <style is="custom-style" include="px-theme-styles"></style>
+  </custom-style>
+
+  <dom-bind>
+    <template is="dom-bind">
+      <px-app-nav
+          items='[
+            { "label" : "Home", "id" : "home", "icon" : "px-fea:home" },
+            { "label" : "Alerts", "id" : "alerts", "icon" : "px-fea:alerts" },
+            { "label" : "Dashboards", "id" : "dashboards", "icon" : "px-fea:dashboard", "children": [
+              { "label" : "See Live Truck View", "id" : "trucks", "icon" : "px-obj:truck" },
+              { "label" : "Track Orders", "id" : "orders", "icon" : "px-fea:orders" },
+              { "label" : "Analyze Invoices", "id" : "invoices", "icon" : "px-fea:templates" }
+            ]}
+          ]'
+          vertical
+          vertical-expanded
+          selected="{{selectedItem}}"
+          selected-route="{{selectedRoute}}"
+          vertical-opened="{{verticalOpened}}">
+        <div slot="actions" class="actions">
+          <template is="dom-if" if="[[verticalOpened]]">
+            <div class="actions-expanded">
+              <span class="email-address">thomas.edison@ge.com</span>
+              <px-icon icon="px-utl:app-settings"></px-icon>
+            </div>
+          </template>
+          <template is="dom-if" if="[[!verticalOpened]]">
+            <div class="actions-collapsed">
+              <px-icon icon="px-utl:app-settings"></px-icon>
+            </div>
+          </template>
+        </div>
+      </px-app-nav>
+
+      <div id="app">
+        <ul>
+          <li>Selected item label: <strong>{{selectedItem.label}}</strong></li>
+          <li>Selected route: <strong>{{selectedRoute}}</strong></li>
+        </ul>
+      </div>
+    </template>
+  </dom-bind>
+</body>
+</html>

--- a/px-app-nav.es6.js
+++ b/px-app-nav.es6.js
@@ -216,6 +216,18 @@
       },
 
       /**
+       * Shows the vertical navigation in an expanded view. The navigation will take up the
+       * full left-hand side of the page.
+       */
+      verticalExpanded: {
+        type: Boolean,
+        value: false,
+        notify: true,
+        reflectToAttribute: true,
+        observer: '_handleVerticalExpandedViewChanged'
+      },
+
+      /**
        * When `true`, the vertical navigation is open and the user is interacting
        * with it. When `false`, the vertical navigation is closed.
        */
@@ -342,6 +354,7 @@
 
     _handleMouseEnter() {
       if (!this.vertical) return;
+      if (this.verticalExpanded) return;
 
       this._mouseIsOverNav = true;
       if (this.isDebouncerActive('close-nav-on-mouseleave')) {
@@ -354,6 +367,7 @@
 
     _handleMouseLeave() {
       if (!this.vertical) return;
+      if (this.verticalExpanded) return;
 
       this._mouseIsOverNav = false;
       this.debounce('close-nav-on-mouseleave', function() {
@@ -393,6 +407,17 @@
       }
     },
 
+    _handleVerticalExpandedViewChanged(verticalExpanded) {
+      if (verticalExpanded) {
+        this._setVerticalOpened(true);
+        this.rebuild();
+      }
+
+      if(!verticalExpanded) {
+        this._setVerticalOpened(false);
+        this._handleResize();
+      }
+    },
     /**
      * Updates the selected item when the user taps on a nav item button.
      */

--- a/px-app-nav.es6.js
+++ b/px-app-nav.es6.js
@@ -353,8 +353,7 @@
     },
 
     _handleMouseEnter() {
-      if (!this.vertical) return;
-      if (this.verticalExpanded) return;
+      if (!this.vertical || this.verticalExpanded) return;
 
       this._mouseIsOverNav = true;
       if (this.isDebouncerActive('close-nav-on-mouseleave')) {
@@ -366,8 +365,7 @@
     },
 
     _handleMouseLeave() {
-      if (!this.vertical) return;
-      if (this.verticalExpanded) return;
+      if (!this.vertical || this.verticalExpanded) return;
 
       this._mouseIsOverNav = false;
       this.debounce('close-nav-on-mouseleave', function() {
@@ -408,15 +406,9 @@
     },
 
     _handleVerticalExpandedViewChanged(verticalExpanded) {
-      if (verticalExpanded) {
-        this._setVerticalOpened(true);
-        this.rebuild();
-      }
-
-      if(!verticalExpanded) {
-        this._setVerticalOpened(false);
-        this._handleResize();
-      }
+      this._setVerticalOpened(verticalExpanded);
+      if (verticalExpanded) this.rebuild();
+      else this._handleResize();
     },
     /**
      * Updates the selected item when the user taps on a nav item button.


### PR DESCRIPTION
…icons and titles for each nav item. On hover, nothing would happen because the nav bar is fixed.

/* Can be achieved by using the vertical-expanded property while using the px-app-nav */

# Pull Request

Hi,

Thanks for helping us improve the Predix UI platform by submitting a Pull Request.

To help us merge your Pull Request as fast as possible, please fill out the following sections:

* ## A description of the changes proposed in the pull request:
The pull request contains the option to add a property called vertical-expanded, which allows the nav bar to be vertical and display its tiles in the expanded view(as seen on hover currently).

* ## A reference to a related issue (if applicable):
We are using the px-app-nav currently, and want to have a solution for implementing the feature stated above.

* ## @mentions of the person or team responsible for reviewing proposed changes:

* ## working tests:
#### The tests need to be functional and/or unit tests, written for the wct framework, and placed in the test folder, following our testing guidelines.
