### PR TITLE
Adding title attribute to item and subitem labels

### DIFF
--- a/px-app-nav-item.html
+++ b/px-app-nav-item.html
@@ -36,7 +36,7 @@ limitations under the License.
     </template>
 
     <template is="dom-if" if="{{_propIsTypeOf(label, 'string')}}">
-      <p class="app-nav-item__label">{{label}}</p>
+      <p title="[[label]]" class="app-nav-item__label">{{label}}</p>
     </template>
 
     <template is="dom-if" if="{{empty}}">

--- a/px-app-nav-subitem.html
+++ b/px-app-nav-subitem.html
@@ -23,7 +23,7 @@ limitations under the License.
     <style include="px-app-nav-subitem-styles"></style>
 
     <template is="dom-if" if="{{_propIsTypeOf(label, 'string')}}">
-      <p class="app-nav-subitem__label">{{label}}</p>
+      <p title="[[label]]" class="app-nav-subitem__label">{{label}}</p>
     </template>
   </template>
 </dom-module>


### PR DESCRIPTION
## A description of the changes proposed in the pull request:
Added `title` attribute to item and subitem labels in order to enable tool tips in case labels are truncated.

## A reference to a related issue (if applicable):
Resolves https://github.com/predixdesignsystem/px-app-nav/issues/90.
